### PR TITLE
Check file content instead of name extension for hitsound files

### DIFF
--- a/checks/all modes/general/audio/CheckHitSoundFormat.cs
+++ b/checks/all modes/general/audio/CheckHitSoundFormat.cs
@@ -69,16 +69,17 @@ namespace MapsetChecks.checks.general.audio
             {
                 foreach (string hitSoundFile in aBeatmapSet.hitSoundFiles)
                 {
-                    var hsType = Path.GetExtension(hitSoundFile);
+                    string hsPath = Path.Combine(aBeatmapSet.songPath, hitSoundFile);
+                    var hsType = Path.GetExtension(hsPath);
                     try {
-                        new Mp3FileReader(hitSoundFile);
+                        new Mp3FileReader(hsPath);
                         hsType = "mp3";
                     } catch {
                         
                     }
 
                     try {
-                        new VorbisReader(hitSoundFile);
+                        new VorbisReader(hsPath);
                         hsType = "ogg";
                     } catch {
 

--- a/checks/all modes/general/audio/CheckHitSoundFormat.cs
+++ b/checks/all modes/general/audio/CheckHitSoundFormat.cs
@@ -78,6 +78,7 @@ namespace MapsetChecks.checks.general.audio
             } catch {
                 // Not .mp3 file.
             }
+
             try {
                 new VorbisReader(hsFullPath);
                 return "ogg";
@@ -97,6 +98,7 @@ namespace MapsetChecks.checks.general.audio
                 {
                     string hsPath = Path.Combine(aBeatmapSet.songPath, hitSoundFile);
                     string hsType = GetFormat(hsPath);
+                    
                     if (hsType == "ogg")
                         yield return new Issue(GetTemplate("ogg"), null,
                             hitSoundFile);

--- a/checks/all modes/general/audio/CheckHitSoundFormat.cs
+++ b/checks/all modes/general/audio/CheckHitSoundFormat.cs
@@ -63,6 +63,32 @@ namespace MapsetChecks.checks.general.audio
             };
         }
 
+        public string GetFormat(string hsFullPath)
+        {
+            try {
+                new WaveFileReader(hsFullPath);
+                return "wav";
+            } catch {
+                // Seems not to be a .wav file, continue.
+            }
+
+            try {
+                new Mp3FileReader(hsFullPath);
+                return "mp3";
+            } catch {
+                // Not .mp3 file.
+            }
+            try {
+                new VorbisReader(hsFullPath);
+                return "ogg";
+            } catch {
+                // Not .ogg file.
+            }
+
+            // Return file's extension instead.
+            return Path.GetExtension(hsFullPath);
+        }
+
         public override IEnumerable<Issue> GetIssues(BeatmapSet aBeatmapSet)
         {
             if (aBeatmapSet.hitSoundFiles != null)
@@ -70,21 +96,7 @@ namespace MapsetChecks.checks.general.audio
                 foreach (string hitSoundFile in aBeatmapSet.hitSoundFiles)
                 {
                     string hsPath = Path.Combine(aBeatmapSet.songPath, hitSoundFile);
-                    var hsType = Path.GetExtension(hsPath);
-                    try {
-                        new Mp3FileReader(hsPath);
-                        hsType = "mp3";
-                    } catch {
-                        
-                    }
-
-                    try {
-                        new VorbisReader(hsPath);
-                        hsType = "ogg";
-                    } catch {
-
-                    }
-
+                    string hsType = GetFormat(hsPath);
                     if (hsType == "ogg")
                         yield return new Issue(GetTemplate("ogg"), null,
                             hitSoundFile);

--- a/checks/all modes/general/audio/CheckHitSoundFormat.cs
+++ b/checks/all modes/general/audio/CheckHitSoundFormat.cs
@@ -4,7 +4,10 @@ using MapsetParser.statics;
 using MapsetVerifierFramework.objects;
 using MapsetVerifierFramework.objects.metadata;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using NAudio.Wave;
+using NVorbis;
 
 namespace MapsetChecks.checks.general.audio
 {
@@ -66,12 +69,27 @@ namespace MapsetChecks.checks.general.audio
             {
                 foreach (string hitSoundFile in aBeatmapSet.hitSoundFiles)
                 {
-                    if (hitSoundFile.EndsWith(".ogg"))
+                    var hsType = Path.GetExtension(hitSoundFile);
+                    try {
+                        new Mp3FileReader(hitSoundFile);
+                        hsType = "mp3";
+                    } catch {
+                        
+                    }
+
+                    try {
+                        new VorbisReader(hitSoundFile);
+                        hsType = "ogg";
+                    } catch {
+
+                    }
+
+                    if (hsType == "ogg")
                         yield return new Issue(GetTemplate("ogg"), null,
                             hitSoundFile);
                     
                     // The .mp3 format includes inherent delays and are as such not fit for active hit sounding.
-                    if (hitSoundFile.EndsWith(".mp3"))
+                    if (hsType == "mp3")
                     {
                         foreach (Beatmap beatmap in aBeatmapSet.beatmaps)
                         {


### PR DESCRIPTION
Background:
There are some mappers who actually use .mp3 files renamed as .wav file format to use it, this causes the hitsound to still delay as they are, indeed, .mp3 file, not a .wav file, here's an example: https://osu.ppy.sh/beatmapsets/1008370#osu/2110740 ([osz](https://puu.sh/E5Rjh/6da0ba669f.osz))

This PR uses NAudio and NVorbis to check whether the contents are .wav, .ogg, or .mp3, instead of checking it's file extension.

Current MV result:
![MV shows no incorrect format](https://puu.sh/E5RjL/5bdad1216c.png)
This PR's MV result:
![MV shows incorrect format](https://puu.sh/E5Ris/cc9f66d5d6.png)