### PR TITLE
Collab tag support

### DIFF
--- a/Checks/AllModes/General/Metadata/CheckGuestTags.cs
+++ b/Checks/AllModes/General/Metadata/CheckGuestTags.cs
@@ -12,7 +12,7 @@ namespace MapsetChecks.Checks.AllModes.General.Metadata
     public class CheckGuestTags : GeneralCheck
     {
         // Matches on a mappers name which can contain any character, number, comma or ampersand.
-        private readonly Regex mapperRegex = new Regex(@"^([a-z0-9&, ]+)(s)'|'s", RegexOptions.IgnoreCase);
+        private readonly Regex mapperRegex = new Regex(@"^([a-z0-9&, ]+)(?:(s)'|'s)", RegexOptions.IgnoreCase);
 
         // Matches on all used split characters for a collab with the used whitespaces
         private readonly Regex collabSplitCharRegex = new Regex(@" & |, ");

--- a/Checks/AllModes/General/Metadata/CheckGuestTags.cs
+++ b/Checks/AllModes/General/Metadata/CheckGuestTags.cs
@@ -62,7 +62,7 @@ namespace MapsetChecks.Checks.AllModes.General.Metadata
                 // e.g. "Alphabet" in "Alphabet's Normal"
                 string possessor = match.Groups[1].Value;
 
-                if (match.Groups.Count == 2)
+                if (match.Groups.Count > 2)
                     // If e.g. "Naxess' Insane", group 1 is "Naxes" and group 2 is the remaining "s".
                     possessor += match.Groups[2].Value;
 


### PR DESCRIPTION
Changed the original matcher regex and now split based the possessor when any of the collab indicators are used.

To see the regex tested, see https://regex101.com/r/e2m2Bq/1/

Note: I did change the namespace since you apparently moved it to `AllModes` a while back without changing the namespace