### PR TITLE
Fix #16 - CheckConcurrent is not properly ignoring concurrent notes in different columns in Mania

### DIFF
--- a/Checks/AllModes/Compose/CheckConcurrent.cs
+++ b/Checks/AllModes/Compose/CheckConcurrent.cs
@@ -78,7 +78,7 @@ namespace MapsetChecks.Checks.AllModes.Compose
                     var otherHitObject = beatmap.hitObjects[j];
 
                     if (beatmap.generalSettings.mode == Beatmap.Mode.Mania &&
-                        hitObject.Position.X.AlmostEqual(otherHitObject.Position.X))
+                        !hitObject.Position.X.AlmostEqual(otherHitObject.Position.X))
                         continue;
 
                     // Only need to check forwards, as any previous object will already have looked behind this one.


### PR DESCRIPTION
Yep, the check just had this condition flipped. This fixes it - tested it on the map shown in the issue (https://osu.ppy.sh/beatmapsets/994104)

Tested that no false positives show up on a good map.
![image](https://github.com/Naxesss/MapsetChecks/assets/5133530/ccef39e9-261d-43d3-8896-f5c0fef75c9e)

Tested by manually putting in a bad concurrent note in a single column.
![image](https://github.com/Naxesss/MapsetChecks/assets/5133530/b80348cd-d936-444f-828b-40dda52704bb)
