### PR TITLE
fix: full/unc paths causing sets to not load

### DIFF
--- a/Common.cs
+++ b/Common.cs
@@ -175,6 +175,11 @@ namespace MapsetChecks
                     {
                         files = new string[] { };
                     }
+                    catch (ArgumentException ex) when (ex.HResult == -2147024809 /* fileName/GetFiles's expression is drive/UNC path */) 
+                    {
+                        files = new string[] { };
+                    }
+                    
 
                     if (files.Length > 0)
                     {


### PR DESCRIPTION
If `Common.GetTagFiles` is called with a filename that is a full path (eg. `C:\\Users\\mini\\image.png`), it causes an exception since that filename is being used in the expression of a `Directory.GetFiles` call to filter for it.
Doing so causes an unhandled exception since the expression must not be a drive or UNC path. This error came across me when an issue in a storybrew script caused a storyboard script to be declared with the full path instead of a path relative to the mapset.

The proposed solution is not ideal, I can imagine this should be some kind of check as beatmap sets should not contain any absolute paths. For now, I changed it so that it's handled the same as when the directory is not found.

![image](https://github.com/user-attachments/assets/17c92a40-08ce-4237-8784-5272309262f8)
